### PR TITLE
Establish initial template for crafter config entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,29 @@
 # System Crafter Configurations
 
-This repository is a collection of configurations created by the System Crafters community!  If you've got a dotfiles repo containing configurations for different applications you use, feel free to add yourself to this page by sending a PR.  You can easily **edit this page by [clicking here](https://github.com/SystemCrafters/crafter-configs/edit/master/README.md)** without the need to clone the repository or create a fork.
+This repository is a collection of configurations created by the System Crafters community!  If you've got a dotfiles repo containing configurations for different applications you use, feel free to [add yourself to this page](#how-to-add-your-config) by sending a PR.
 
-## David Wilson ([@daviwil](https://github.com/daviwil))
+## Crafters
+
+### David Wilson ([@daviwil](https://github.com/daviwil))
 
 I've developed a whole system configuration based around Emacs, EXWM, and Guix which gets shared between multiple machines.  My configuration files are mostly stored in Org Mode files and exported with Org Babel.
 
 - **Config Repo:** https://github.com/daviwil/dotfiles
 - **Operating System:** GNU Guix
 - **Software:** Emacs, Guix, Vimb, Polybar, Dunst, mpv, GNU Stow
+- **Keyboard:** Since I'm a ThinkPad fan, I use the [ThinkPad Compact USB Keyboard](https://www.amazon.com/Lenovo-ThinkPad-Compact-Keyboard-TrackPoint/dp/B00F3U4TQS/ref=sr_1_3?crid=1P0R7L5JJA8CG&dchild=1&keywords=thinkpad+usb+keyboard&qid=1604238423&sprefix=thinkpad+usb+keyboard%2Caps%2C-1&sr=8-3)
 
-## Name ([@username](https://github.com/username)) (Copy this template for your entry!)
+## How to Add Your Config
+
+You can easily **edit this page by [clicking here](https://github.com/SystemCrafters/crafter-configs/edit/master/README.md)** without the need to clone the repository or create a fork.  Feel free to fork and clone if you prefer, though :)
+
+Copy the example block below and paste it in the "Crafters" section above at the end of the list then fill in the sections to match other entires you see in this file.  **Feel free to file issues with suggestions** for other sections to be added!
+
+### Name ([@username](https://github.com/username))
+
+[Give a brief description of your setup and anything you feel is interesting about it!]
 
 - **Config Repo:** [A link to your configuration repo wherever it is hosted]
 - **Operating System:** [This can just be Windows, macOS, or Linux, or it could be your specific Linux distribution]
 - **Software:** [The list of software you use in your configuration]
+- **Keyboard:** [Keyboard type/model/layout, Key re-mappings etc.]


### PR DESCRIPTION
Hey @SystemCrafters/sponsors, I'd love to get your feedback on the format for this repo!  Basically the idea is that I'd like to have a place where members of the community can link to their own personal configurations so that we can all share ideas and patterns for the various tools that we use.

Here are some other ideas for what each person could include:

- Editor theme
- Username in the System Crafters Discord
- Social media username (Twitter, Reddit, etc, only whatever the person is comfortable listing)

What do you think?